### PR TITLE
Meeting overview

### DIFF
--- a/pkg/web/chair.go
+++ b/pkg/web/chair.go
@@ -9,7 +9,9 @@
 package web
 
 import (
+	"encoding/csv"
 	"errors"
+	"fmt"
 	"net/http"
 	"slices"
 	"strings"
@@ -445,4 +447,115 @@ func (c *Controller) meetingsOverview(w http.ResponseWriter, r *http.Request) {
 		"Overview":  overview,
 	}
 	check(w, r, c.tmpls.ExecuteTemplate(w, "meetings_overview.tmpl", data))
+}
+
+func (c *Controller) meetingsExport(w http.ResponseWriter, r *http.Request) {
+	var (
+		committeeID, err = misc.Atoi64(r.FormValue("committee"))
+		ctx              = r.Context()
+	)
+	if !checkParam(w, err) {
+		return
+	}
+	const limit = -1
+	overview, err := models.LoadMeetingsOverview(ctx, c.db, committeeID, limit)
+	if !check(w, r, err) {
+		return
+	}
+
+	// Set headers for CSV download
+	w.Header().Set("Content-Type", "text/csv")
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment;filename=meetings_%d.csv", committeeID))
+
+	// Create CSV writer
+	writer := csv.NewWriter(w)
+	defer writer.Flush()
+
+	// Write CSV header
+	header := []string{
+		"Meeting ID",
+		"Start Time",
+		"Stop Time",
+		"Status",
+		"Gathering",
+		"Description",
+		"Quorum Reached",
+		"Quorum Percent",
+		"Attending Voting",
+		"Total Attendees",
+		"Attendees",
+		"Non-Attendees",
+	}
+	if err := writer.Write(header); err != nil {
+		check(w, r, err)
+		return
+	}
+
+	// Write meeting data
+	for _, meetingData := range overview.Data {
+		meeting := meetingData.Meeting
+		quorum := meetingData.Quorum
+		// Convert Status to string
+		var status string
+		switch meeting.Status {
+		case models.MeetingOnHold:
+			status = "On Hold"
+		case models.MeetingRunning:
+			status = "Running"
+		case models.MeetingConcluded:
+			status = "Concluded"
+		default:
+			status = "Could not load Status"
+		}
+		// Get description
+		description := ""
+		if meeting.Description != nil {
+			description = *meeting.Description
+		}
+
+		// All attendees
+		totalAttendees := len(meetingData.Attendees)
+
+		var attendeesList []string
+		for nickname, voting := range meetingData.Attendees {
+			status := "non-voting"
+			if voting {
+				status = "voting"
+			}
+			attendeesList = append(attendeesList, fmt.Sprintf("%s:%s", nickname, status))
+		}
+		// Convert to String to write to CSV
+		AttendeesString := strings.Join(attendeesList, ",")
+
+		// All users except those who attended to get a list of all non-Attendees
+		var nonAttendeesList []string
+		for _, user := range overview.Users {
+			if _, attended := meetingData.Attendees[user.Nickname]; !attended {
+				nonAttendeesList = append(nonAttendeesList, user.Nickname)
+			}
+		}
+		// Convert to String to write to CSV
+		nonAttendeesString := strings.Join(nonAttendeesList, ",")
+
+		// Gather all data
+		data := []string{
+			fmt.Sprintf("%d", meeting.ID),
+			meeting.StartTime.Format("2006-01-02 15:04:05"),
+			meeting.StopTime.Format("2006-01-02 15:04:05"),
+			status,
+			fmt.Sprintf("%t", meeting.Gathering),
+			description,
+			fmt.Sprintf("%t", quorum.Reached()),
+			fmt.Sprintf("%.2f", quorum.Percent()),
+			fmt.Sprintf("%d", quorum.AttendingVoting),
+			fmt.Sprintf("%d", totalAttendees),
+			AttendeesString,
+			nonAttendeesString,
+		}
+		// and write it to a file
+		if err := writer.Write(data); err != nil {
+			check(w, r, err)
+			return
+		}
+	}
 }

--- a/pkg/web/chair.go
+++ b/pkg/web/chair.go
@@ -525,7 +525,7 @@ func (c *Controller) meetingsExport(w http.ResponseWriter, r *http.Request) {
 			attendeesList = append(attendeesList, fmt.Sprintf("%s:%s", nickname, status))
 		}
 		// Convert to String to write to CSV
-		AttendeesString := strings.Join(attendeesList, ",")
+		attendeesString := strings.Join(attendeesList, ",")
 
 		// All users except those who attended to get a list of all non-Attendees
 		var nonAttendeesList []string
@@ -549,7 +549,7 @@ func (c *Controller) meetingsExport(w http.ResponseWriter, r *http.Request) {
 			fmt.Sprintf("%.2f", quorum.Percent()),
 			fmt.Sprintf("%d", quorum.AttendingVoting),
 			fmt.Sprintf("%d", totalAttendees),
-			AttendeesString,
+			attendeesString,
 			nonAttendeesString,
 		}
 		// and write it to a file

--- a/pkg/web/controller.go
+++ b/pkg/web/controller.go
@@ -153,6 +153,7 @@ func (c *Controller) Bind() http.Handler {
 		{"/meeting_status", mw.CommitteeRoles(c.meetingStatus, models.ChairRole, models.MemberRole, models.SecretaryRole)},
 		{"/meeting_status_store", mw.CommitteeRoles(c.meetingStatusStore, models.ChairRole, models.SecretaryRole)},
 		{"/meeting_attend_store", mw.CommitteeRoles(c.meetingAttendStore, models.ChairRole, models.SecretaryRole)},
+		{"/meetings_export", mw.CommitteeRoles(c.meetingsExport, models.ChairRole, models.SecretaryRole)},
 		// Member
 		{"/member", mw.Roles(c.member, models.MemberRole)},
 		{"/member_attend", mw.CommitteeRoles(c.memberAttend, models.MemberRole)},

--- a/pkg/web/controller.go
+++ b/pkg/web/controller.go
@@ -144,7 +144,7 @@ func (c *Controller) Bind() http.Handler {
 		{"/committee_store", mw.Admin(c.committeeStore)},
 		// Chair and Secretary
 		{"/chair", mw.Roles(c.chair, models.ChairRole, models.SecretaryRole)},
-		{"/meetings_overview", mw.CommitteeRoles(c.meetingsOverview, models.ChairRole, models.SecretaryRole)},
+		{"/meetings_overview", mw.CommitteeRoles(c.meetingsOverview, models.ChairRole, models.MemberRole, models.SecretaryRole)},
 		{"/meetings_store", mw.CommitteeRoles(c.meetingsStore, models.ChairRole, models.SecretaryRole)},
 		{"/meeting_create", mw.CommitteeRoles(c.meetingCreate, models.ChairRole, models.SecretaryRole)},
 		{"/meeting_create_store", mw.CommitteeRoles(c.meetingCreateStore, models.ChairRole, models.SecretaryRole)},

--- a/web/templates/meetings_overview.tmpl
+++ b/web/templates/meetings_overview.tmpl
@@ -10,6 +10,7 @@ Software-Engineering: 2025 Intevation GmbH <https://intevation.de>
 {{ template "header" . }}
 {{- $sessionID   := .Session.ID }}
 {{- $committeeID := .Committee.ID }}
+{{ $chair  := .User.CountMemberships (Role "chair") (Role "secretary") }}
 <fieldset>
 <legend>Meetings: <strong>{{ .Committee.Name }}</strong></legend>
 {{- $data := .Overview.Data }}
@@ -87,4 +88,8 @@ Software-Engineering: 2025 Intevation GmbH <https://intevation.de>
   </table>
 </fieldset>
 {{- end }}
+
+{{ if $chair }}
+  <a href="/meetings_export?SESSIONID={{ $sessionID }}&committee={{ $committeeID }}">Export as CSV</a>
+{{ end }}
 {{ template "footer" }}

--- a/web/templates/member.tmpl
+++ b/web/templates/member.tmpl
@@ -66,6 +66,7 @@ Software-Engineering: 2025 Intevation GmbH <https://intevation.de>
   <legend>Committee: <strong>{{ .Name }}</strong></legend>
   {{ $filter := CommitteeIDFilter .ID }}
   {{ if $meetings.Contains $filter }}
+  <a href="/meetings_overview?SESSIONID={{ $sessionID }}&committee={{ $committeeID }}">Meetings overview</a><br>
   <table>
   <thead>
     <tr>


### PR DESCRIPTION
Fixes https://github.com/csaf-auxiliary/oasis-quorum-calculator/issues/32

meetingsExport gathers all data similar to the overview and writes them to a csv file.
The button to trigger this function is now for Chairs and Secretaries at the bottom of the TC on the overview.

Normal members now get a new button that leads them to the meetings overview, the same as the one from the chairs view. 