### PR TITLE
rephrase attending buttons, add attending buttons to meeting page

### DIFF
--- a/pkg/web/member.go
+++ b/pkg/web/member.go
@@ -9,6 +9,7 @@
 package web
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -63,5 +64,15 @@ func (c *Controller) memberAttend(w http.ResponseWriter, r *http.Request) {
 	if !check(w, r, models.UpdateAttendee(ctx, c.db, meetingID, user.Nickname, attend, voting)) {
 		return
 	}
-	c.member(w, r)
+	// new parameter where to redirect
+	redirect := r.FormValue("redirect")
+
+	switch redirect {
+	case "meeting_status":
+		sessionID := r.FormValue("SESSIONID")
+		target := fmt.Sprintf("/meeting_status?SESSIONID=%s&meeting=%d&committee=%d", sessionID, meetingID, committeeID)
+		http.Redirect(w, r, target, http.StatusSeeOther)
+	default:
+		c.member(w, r)
+	}
 }

--- a/web/templates/meeting_status.tmpl
+++ b/web/templates/meeting_status.tmpl
@@ -23,10 +23,23 @@ Software-Engineering: 2025 Intevation GmbH <https://intevation.de>
 {{- $allowWrite     := and $running $chair }}
 {{- $concluded      := eq .Meeting.Status (MeetingStatus "concluded") }}
 {{- $notOnlyMember  := or .User.IsAdmin $chair -}}
+{{- $userNickname   := .User.Nickname }}
+
 {{- if $running }}
 <p><a href="/meeting_status?SESSIONID={{ $sessionID }}&meeting={{ $meetingID }}&committee={{ $committeeID }}"
       >&#x27F3; Refresh to see who has attended recently.</a>
 </p>
+
+{{- if not (index $attendees $userNickname) }}
+<a href="/member_attend?SESSIONID={{ $sessionID }}&meeting={{ $meetingID }}&committee={{ $committeeID }}&attend=true&redirect=meeting_status">
+  <mark>Click&nbsp;to&nbsp;record&nbsp;my&nbsp;attendance!</mark>
+</a>
+{{ else }}
+<a href="/member_attend?SESSIONID={{ $sessionID }}&meeting={{ $meetingID }}&committee={{ $committeeID }}&attend=false&redirect=meeting_status">
+  <mark>Click&nbsp;to&nbsp;unregister&nbsp;my&nbsp;attendance!</mark>
+</a>
+{{ end }}
+
 {{- end }}
 <p>
 <strong>Committee</strong>: {{ $committeeName }}<br>

--- a/web/templates/member.tmpl
+++ b/web/templates/member.tmpl
@@ -39,10 +39,10 @@ Software-Engineering: 2025 Intevation GmbH <https://intevation.de>
                  ><strong>{{ ($user.CommitteeByID $committeeID).Name }}</strong></a>
               {{- if eq .Status $meetingRunning }}
                 {{ if $att }}<a href="/member_attend?SESSIONID={{ $sessionID }}&meeting={{ .ID }}&committee={{ $committeeID }}&attend=false">
-                <mark>Click&nbsp;to&nbsp;skip!</mark></a>
+                <mark>Click&nbsp;to&nbsp;unregister&nbsp;my&nbsp;attendance!</mark></a>
                 {{- else -}}
                 <a href="/member_attend?SESSIONID={{ $sessionID }}&meeting={{ .ID }}&committee={{ $committeeID }}&attend=true">
-                <mark>Click&nbsp;to&nbsp;join!</mark></a>
+                <mark>Click&nbsp;to&nbsp;record&nbsp;my&nbsp;attendance!</mark></a>
                 {{- end -}}
               {{- end }}
             </td>
@@ -86,8 +86,8 @@ Software-Engineering: 2025 Intevation GmbH <https://intevation.de>
           {{- else }}Concluded{{ if $att }} (Attended){{ end }}{{ end -}}
         </a>
         {{- if eq .Status $meetingRunning }}
-          {{ if $att }}<a href="/member_attend?SESSIONID={{ $sessionID }}&meeting={{ .ID }}&committee={{ $committeeID }}&attend=false"><mark>Click&nbsp;to&nbsp;skip!</mark></a>
-          {{- else }}<a href="/member_attend?SESSIONID={{ $sessionID }}&meeting={{ .ID }}&committee={{ $committeeID }}&attend=true"><mark>Click&nbsp;to&nbsp;join!</mark></a>{{ end -}}
+          {{ if $att }}<a href="/member_attend?SESSIONID={{ $sessionID }}&meeting={{ .ID }}&committee={{ $committeeID }}&attend=false"><mark>Click&nbsp;to&nbsp;unregister&nbsp;my&nbsp;attendance!</mark></a>
+          {{- else }}<a href="/member_attend?SESSIONID={{ $sessionID }}&meeting={{ .ID }}&committee={{ $committeeID }}&attend=true"><mark>Click&nbsp;to&nbsp;record&nbsp;my&nbsp;attendance!</mark></a>{{ end -}}
         {{- end }}
       </td>
       <td>


### PR DESCRIPTION
fixes https://github.com/csaf-auxiliary/oasis-quorum-calculator/issues/48

Attend button now can redirect to more places, but only the old one as default and the meeting overview if it was triggered from there are configured.

Attend button now also is in the meeting overview.

All attend/unattend buttons got new text.