### PR TITLE
Fix user deletion

### DIFF
--- a/pkg/database/migrations/000-setup.sql
+++ b/pkg/database/migrations/000-setup.sql
@@ -143,3 +143,14 @@ CREATE TABLE member_absent (
     CHECK (start_time < stop_time),
     UNIQUE (nickname, committee_id, start_time)
 );
+
+CREATE TRIGGER delete_references_before_user
+BEFORE DELETE ON users
+FOR EACH ROW
+BEGIN
+    DELETE FROM attendees         WHERE nickname = OLD.nickname;
+    DELETE FROM attendees_changes WHERE nickname = OLD.nickname;
+    DELETE FROM committee_roles   WHERE nickname = OLD.nickname;
+    DELETE FROM sessions          WHERE nickname = OLD.nickname;
+    DELETE FROM member_absent     WHERE nickname = OLD.nickname;
+END;

--- a/pkg/database/migrations/004-user_delete.sql
+++ b/pkg/database/migrations/004-user_delete.sql
@@ -1,0 +1,18 @@
+-- This file is Free Software under the Apache-2.0 License
+-- without warranty, see README.md and LICENSE for details.
+--
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- SPDX-FileCopyrightText: 2025 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+-- Software-Engineering: 2025 Intevation GmbH <https://intevation.de>
+
+CREATE TRIGGER delete_references_before_user
+    BEFORE DELETE ON users
+    FOR EACH ROW
+BEGIN
+    DELETE FROM attendees         WHERE nickname = OLD.nickname;
+    DELETE FROM attendees_changes WHERE nickname = OLD.nickname;
+    DELETE FROM committee_roles   WHERE nickname = OLD.nickname;
+    DELETE FROM sessions          WHERE nickname = OLD.nickname;
+    DELETE FROM member_absent     WHERE nickname = OLD.nickname;
+END;


### PR DESCRIPTION
SQLite does not support deferrable `UNIQUE` constraints. To workaround this issue all entries that can have a reference to the user are deleted. For better traceability of past meetings, the user deletion may be removed in the future.