### PR TITLE
Meeting endtimer

### DIFF
--- a/cmd/importcommittee/main.go
+++ b/cmd/importcommittee/main.go
@@ -287,7 +287,7 @@ func run(committee, csv, databaseURL string) error {
 			return err
 		}
 
-		if err = models.ChangeMeetingStatus(ctx, db, meeting.ID, committeeModel.ID, models.MeetingConcluded); err != nil {
+		if err = models.ChangeMeetingStatus(ctx, db, meeting.ID, committeeModel.ID, models.MeetingConcluded, meeting.StopTime); err != nil {
 			return err
 		}
 	}

--- a/cmd/importcommittee/main.go
+++ b/cmd/importcommittee/main.go
@@ -207,6 +207,9 @@ func run(committee, csv, databaseURL string) error {
 	}
 	defer db.Close(ctx)
 	committees, err := models.LoadCommittees(ctx, db)
+	if err != nil {
+		return err
+	}
 
 	var committeeModel *models.Committee
 	for _, c := range committees {

--- a/pkg/misc/times.go
+++ b/pkg/misc/times.go
@@ -15,9 +15,8 @@ import (
 
 // CalculateEndpoint determines whether time.Now is happening during a duration from a set point in time.
 // If it is, then time.Now() is returned, otherwise the endpoint of the duration is returned.
-func CalculateEndpoint(begin time.Time, duration time.Duration) time.Time {
+func CalculateEndpoint(begin time.Time, end time.Time) time.Time {
 	now := time.Now()
-	end := begin.Add(duration)
 
 	if now.After(begin) && now.Before(end) {
 		return now

--- a/pkg/misc/times.go
+++ b/pkg/misc/times.go
@@ -1,0 +1,26 @@
+// This file is Free Software under the Apache-2.0 License
+// without warranty, see README.md and LICENSE for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: 2025 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2025 Intevation GmbH <https://intevation.de>
+
+// Package misc implements miscellaneous functions.
+package misc
+
+import (
+	"time"
+)
+
+// CalculateEndpoint determines whether time.Now is happening during a duration from a set point in time.
+// If it is, then time.Now() is returned, otherwise the endpoint of the duration is returned.
+func CalculateEndpoint(begin time.Time, duration time.Duration) time.Time {
+	now := time.Now()
+	end := begin.Add(duration)
+
+	if now.After(begin) && now.Before(end) {
+		return now
+	}
+	return end
+}

--- a/pkg/models/meeting_status_change.go
+++ b/pkg/models/meeting_status_change.go
@@ -37,6 +37,7 @@ func ChangeMeetingStatus(
 	db *database.Database,
 	meetingID, committeeID int64,
 	meetingStatus MeetingStatus,
+	timer time.Time,
 ) error {
 
 	// Extra checks before we try to change the status.
@@ -186,14 +187,13 @@ func ChangeMeetingStatus(
 
 		// Store the changes.
 		if len(upgrades) > 0 || len(downgrades) > 0 {
-			when := time.Now() // TODO: Should we adjust the end time of the meeting?
 			if err := UpdateUserCommitteeStatusTx(
 				ctx, tx,
 				misc.Join2(
 					misc.Attribute(slices.Values(upgrades), Voting),
 					misc.Attribute(slices.Values(downgrades), Member)),
 				committeeID,
-				when,
+				timer,
 			); err != nil {
 				return fmt.Errorf("upgrading / downgrading members failed: %w", err)
 			}

--- a/pkg/web/chair.go
+++ b/pkg/web/chair.go
@@ -483,13 +483,18 @@ func (c *Controller) meetingStatusStore(w http.ResponseWriter, r *http.Request) 
 		committeeID, err2   = misc.Atoi64(r.FormValue("committee"))
 		meetingStatus, err3 = models.ParseMeetingStatus(r.FormValue("status"))
 		ctx                 = r.Context()
+		begin, err4         = time.Parse(time.RFC3339, r.FormValue("begin"))
+		duration, err5      = time.ParseDuration(r.FormValue("duration"))
 	)
-	if !checkParam(w, err1, err2, err3) {
+	if !checkParam(w, err1, err2, err3, err4, err5) {
 		return
 	}
+	// Whether to use time.Now() or not
+	timer := misc.CalculateEndpoint(begin, duration)
 	switch err := models.ChangeMeetingStatus(
 		ctx, c.db,
 		meetingID, committeeID, meetingStatus,
+		timer,
 	); {
 	case errors.Is(err, models.ErrAlreadyRunning):
 		c.meetingStatusError(w, r, "Already have a running meeting in this committee.")

--- a/web/templates/meeting_status.tmpl
+++ b/web/templates/meeting_status.tmpl
@@ -65,12 +65,12 @@ Software-Engineering: 2025 Intevation GmbH <https://intevation.de>
 {{ if or $chair $secretary }}
 {{ if $concluded }}Concluded{{ else }}
 {{- if $onhold }}[Waiting]
-{{- else }}[<a href="/meeting_status_store?SESSIONID={{ $sessionID }}&meeting={{ $meetingID }}&committee={{ $committeeID }}&begin={{ .Meeting.StartTime.UTC.Format "2006-01-02T15:04:05Z07:00" }}&duration={{ .Meeting.Duration }}&status=onhold">Pause</a>]
+{{- else }}[<a href="/meeting_status_store?SESSIONID={{ $sessionID }}&meeting={{ $meetingID }}&committee={{ $committeeID }}&status=onhold">Pause</a>]
 {{- end }}
 {{ if or $running $alreadyRunning }}[Running]
-{{- else }}[<a href="/meeting_status_store?SESSIONID={{ $sessionID }}&meeting={{ $meetingID }}&committee={{ $committeeID }}&begin={{ .Meeting.StartTime.UTC.Format "2006-01-02T15:04:05Z07:00" }}&duration={{ .Meeting.Duration }}&status=running">Run</a>]
+{{- else }}[<a href="/meeting_status_store?SESSIONID={{ $sessionID }}&meeting={{ $meetingID }}&committee={{ $committeeID }}&status=running">Run</a>]
 {{- end }}
-[<a href="/meeting_status_store?SESSIONID={{ $sessionID }}&meeting={{ $meetingID }}&committee={{ $committeeID }}&begin={{ .Meeting.StartTime.UTC.Format "2006-01-02T15:04:05Z07:00" }}&duration={{ .Meeting.Duration }}&status=concluded">Conclude</a>]
+[<a href="/meeting_status_store?SESSIONID={{ $sessionID }}&meeting={{ $meetingID }}&committee={{ $committeeID }}&status=concluded">Conclude</a>]
 {{ end }}
 {{ else }}
 {{ if $concluded }}Concluded

--- a/web/templates/meeting_status.tmpl
+++ b/web/templates/meeting_status.tmpl
@@ -65,12 +65,12 @@ Software-Engineering: 2025 Intevation GmbH <https://intevation.de>
 {{ if or $chair $secretary }}
 {{ if $concluded }}Concluded{{ else }}
 {{- if $onhold }}[Waiting]
-{{- else }}[<a href="/meeting_status_store?SESSIONID={{ $sessionID }}&meeting={{ $meetingID }}&committee={{ $committeeID }}&status=onhold">Pause</a>]
+{{- else }}[<a href="/meeting_status_store?SESSIONID={{ $sessionID }}&meeting={{ $meetingID }}&committee={{ $committeeID }}&begin={{ .Meeting.StartTime.UTC.Format "2006-01-02T15:04:05Z07:00" }}&duration={{ .Meeting.Duration }}&status=onhold">Pause</a>]
 {{- end }}
 {{ if or $running $alreadyRunning }}[Running]
-{{- else }}[<a href="/meeting_status_store?SESSIONID={{ $sessionID }}&meeting={{ $meetingID }}&committee={{ $committeeID }}&status=running">Run</a>]
+{{- else }}[<a href="/meeting_status_store?SESSIONID={{ $sessionID }}&meeting={{ $meetingID }}&committee={{ $committeeID }}&begin={{ .Meeting.StartTime.UTC.Format "2006-01-02T15:04:05Z07:00" }}&duration={{ .Meeting.Duration }}&status=running">Run</a>]
 {{- end }}
-[<a href="/meeting_status_store?SESSIONID={{ $sessionID }}&meeting={{ $meetingID }}&committee={{ $committeeID }}&status=concluded">Conclude</a>]
+[<a href="/meeting_status_store?SESSIONID={{ $sessionID }}&meeting={{ $meetingID }}&committee={{ $committeeID }}&begin={{ .Meeting.StartTime.UTC.Format "2006-01-02T15:04:05Z07:00" }}&duration={{ .Meeting.Duration }}&status=concluded">Conclude</a>]
 {{ end }}
 {{ else }}
 {{ if $concluded }}Concluded


### PR DESCRIPTION
Allow precise timing of member status changes. Changes made outside the meetings runtime are set at having happened at the end of the meeting.