### PR TITLE
docs: improve docs/installation hints

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -31,6 +31,7 @@ After=network.target
 Type=idle
 User=oqc
 Group=oqc
+RuntimeDirectory=oqc
 WorkingDirectory=/opt/oqc
 ExecStart=/opt/oqc/bin/oqcd -c /opt/oqc/oqcd.toml
 


### PR DESCRIPTION
  * add `RuntimeDirectory=oqc` to system example so that /run/oqc gets created automatically after a reboot.